### PR TITLE
修正二手書API 

### DIFF
--- a/app/controllers/books_controller.rb
+++ b/app/controllers/books_controller.rb
@@ -1,5 +1,6 @@
 class BooksController < ApplicationController
   before_action :set_book, only: [:show, :update, :destroy]
+  before_action :authenticate_user!, except: [:index, :show]
 
   # GET /books
   def index
@@ -36,7 +37,9 @@ class BooksController < ApplicationController
 
   # PATCH/PUT /books/1
   def update
-    if @book.update(book_params)
+    if current_user.id != @book.user_id
+      render json: { "error": "user doesn't match" }, status: :unauthorized
+    elsif @book.update(book_params)
       render json: @book
     else
       render json: @book.errors, status: :unprocessable_entity
@@ -45,7 +48,11 @@ class BooksController < ApplicationController
 
   # DELETE /books/1
   def destroy
-    @book.destroy
+    if current_user.id != @book.user_id
+      render json: { "error": "user doesn't match" }, status: :unauthorized
+    else
+      @book.destroy
+    end
   end
 
   private

--- a/app/controllers/books_controller.rb
+++ b/app/controllers/books_controller.rb
@@ -25,7 +25,7 @@ class BooksController < ApplicationController
 
   # POST /books
   def create
-    @book = Book.new(book_params)
+    @book = current_user.books.build(book_params)
 
     if @book.save
       render json: @book, status: :created, location: @book

--- a/app/models/book.rb
+++ b/app/models/book.rb
@@ -11,8 +11,12 @@ class Book < ApplicationRecord
     options = options.try(:dup) || {}
 
     super({ **options, except: :user_id }).tap do |result|
-      result[:user] = user
-      result[:courses] = courses
+      result[:user] = user.serializable_hash(only: [:id, :name])
+      result[:courses] = [].tap do |i|
+        courses.each do |course|
+          i << course.serializable_hash_for_books
+        end
+      end
     end
   end
 end

--- a/app/models/course.rb
+++ b/app/models/course.rb
@@ -54,4 +54,16 @@ class Course < ApplicationRecord
       result[:ratings] = ratings
     end
   end
+
+  def serializable_hash_for_books
+    {}.tap do |result|
+      result[:course_id] = id
+      result[:course_name] = permanent_course.name
+      result[:teachers] = [].tap do |i|
+        teachers.each do |teacher|
+          i << teacher.serializable_hash_for_books
+        end
+      end
+    end
+  end
 end

--- a/app/models/teacher.rb
+++ b/app/models/teacher.rb
@@ -7,4 +7,11 @@ class Teacher < ApplicationRecord
   self.primary_key = :id
   has_many :teachers_courses
   has_many :courses, through: :teachers_courses
+
+  def serializable_hash_for_books
+    {}.tap do |result|
+      result[:id] = id
+      result[:name] = name
+    end
+  end
 end

--- a/db/migrate/20181017051742_add_contact_way_to_books.rb
+++ b/db/migrate/20181017051742_add_contact_way_to_books.rb
@@ -1,0 +1,5 @@
+class AddContactWayToBooks < ActiveRecord::Migration[5.2]
+  def change
+    add_column :books, :contact_way, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,9 +10,9 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2018_09_05_030558) do
+ActiveRecord::Schema.define(version: 2018_10_17_051742) do
 
-  create_table "books", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4", force: :cascade do |t|
+  create_table "books", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci", force: :cascade do |t|
     t.string "name"
     t.string "isbn"
     t.string "authors"
@@ -25,10 +25,11 @@ ActiveRecord::Schema.define(version: 2018_09_05_030558) do
     t.integer "view_count", default: 0, null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.string "contact_way"
     t.index ["user_id"], name: "index_books_on_user_id"
   end
 
-  create_table "books_courses", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4", force: :cascade do |t|
+  create_table "books_courses", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci", force: :cascade do |t|
     t.bigint "book_id"
     t.bigint "course_id"
     t.datetime "created_at", null: false
@@ -37,7 +38,7 @@ ActiveRecord::Schema.define(version: 2018_09_05_030558) do
     t.index ["course_id"], name: "index_books_courses_on_course_id"
   end
 
-  create_table "bulletins", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4", force: :cascade do |t|
+  create_table "bulletins", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci", force: :cascade do |t|
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.string "title", default: "untitled", null: false
@@ -49,14 +50,14 @@ ActiveRecord::Schema.define(version: 2018_09_05_030558) do
     t.index ["author_id"], name: "index_bulletins_on_author_id"
   end
 
-  create_table "colleges", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4", force: :cascade do |t|
+  create_table "colleges", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci", force: :cascade do |t|
     t.string "name"
     t.string "code", limit: 1, null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
   end
 
-  create_table "course_ratings", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4", force: :cascade do |t|
+  create_table "course_ratings", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci", force: :cascade do |t|
     t.bigint "course_id"
     t.integer "category"
     t.integer "score"
@@ -65,7 +66,7 @@ ActiveRecord::Schema.define(version: 2018_09_05_030558) do
     t.index ["course_id"], name: "index_course_ratings_on_course_id"
   end
 
-  create_table "courses", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4", force: :cascade do |t|
+  create_table "courses", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci", force: :cascade do |t|
     t.string "code"
     t.string "remarks"
     t.integer "credit"
@@ -89,7 +90,7 @@ ActiveRecord::Schema.define(version: 2018_09_05_030558) do
     t.index ["semester_id"], name: "index_courses_on_semester_id"
   end
 
-  create_table "departments", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4", force: :cascade do |t|
+  create_table "departments", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci", force: :cascade do |t|
     t.string "name"
     t.integer "category", default: 0, null: false
     t.string "department_type", limit: 1
@@ -100,7 +101,7 @@ ActiveRecord::Schema.define(version: 2018_09_05_030558) do
     t.index ["college_id"], name: "index_departments_on_college_id"
   end
 
-  create_table "events", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4", force: :cascade do |t|
+  create_table "events", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci", force: :cascade do |t|
     t.integer "event_type"
     t.string "title", default: "untitled", null: false
     t.string "organization"
@@ -118,7 +119,7 @@ ActiveRecord::Schema.define(version: 2018_09_05_030558) do
     t.index ["user_id"], name: "index_events_on_user_id"
   end
 
-  create_table "past_exams", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4", force: :cascade do |t|
+  create_table "past_exams", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci", force: :cascade do |t|
     t.string "description"
     t.integer "download_count", default: 0
     t.string "file"
@@ -130,7 +131,7 @@ ActiveRecord::Schema.define(version: 2018_09_05_030558) do
     t.index ["uploader_id"], name: "index_past_exams_on_uploader_id"
   end
 
-  create_table "permanent_courses", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4", force: :cascade do |t|
+  create_table "permanent_courses", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci", force: :cascade do |t|
     t.string "name"
     t.string "code"
     t.string "description"
@@ -138,20 +139,21 @@ ActiveRecord::Schema.define(version: 2018_09_05_030558) do
     t.datetime "updated_at", null: false
   end
 
-  create_table "semesters", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4", force: :cascade do |t|
+  create_table "semesters", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci", force: :cascade do |t|
     t.integer "year"
     t.integer "term"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
   end
 
-  create_table "teachers", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4", force: :cascade do |t|
+  create_table "teachers", id: false, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci", force: :cascade do |t|
+    t.integer "id"
     t.string "name"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
   end
 
-  create_table "teachers_courses", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4", force: :cascade do |t|
+  create_table "teachers_courses", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci", force: :cascade do |t|
     t.bigint "teacher_id"
     t.bigint "course_id"
     t.datetime "created_at", null: false
@@ -160,7 +162,7 @@ ActiveRecord::Schema.define(version: 2018_09_05_030558) do
     t.index ["teacher_id"], name: "index_teachers_courses_on_teacher_id"
   end
 
-  create_table "timetables", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4", force: :cascade do |t|
+  create_table "timetables", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci", force: :cascade do |t|
     t.bigint "user_id"
     t.boolean "shareable", default: false
     t.datetime "created_at", null: false
@@ -168,7 +170,7 @@ ActiveRecord::Schema.define(version: 2018_09_05_030558) do
     t.index ["user_id"], name: "index_timetables_on_user_id"
   end
 
-  create_table "timetables_courses", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4", force: :cascade do |t|
+  create_table "timetables_courses", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci", force: :cascade do |t|
     t.bigint "timetable_id"
     t.bigint "course_id"
     t.datetime "created_at", null: false
@@ -177,7 +179,7 @@ ActiveRecord::Schema.define(version: 2018_09_05_030558) do
     t.index ["timetable_id"], name: "index_timetables_courses_on_timetable_id"
   end
 
-  create_table "users", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4", force: :cascade do |t|
+  create_table "users", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci", force: :cascade do |t|
     t.string "provider", default: "email", null: false
     t.string "uid", default: "", null: false
     t.string "encrypted_password", default: "", null: false
@@ -208,7 +210,7 @@ ActiveRecord::Schema.define(version: 2018_09_05_030558) do
     t.index ["uid", "provider"], name: "index_users_on_uid_and_provider", unique: true
   end
 
-  create_table "users_course_ratings", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4", force: :cascade do |t|
+  create_table "users_course_ratings", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci", force: :cascade do |t|
     t.bigint "user_id"
     t.bigint "course_rating_id"
     t.datetime "created_at", null: false
@@ -217,7 +219,7 @@ ActiveRecord::Schema.define(version: 2018_09_05_030558) do
     t.index ["user_id"], name: "index_users_course_ratings_on_user_id"
   end
 
-  create_table "users_courses", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4", force: :cascade do |t|
+  create_table "users_courses", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci", force: :cascade do |t|
     t.bigint "user_id"
     t.bigint "course_id"
     t.datetime "created_at", null: false
@@ -226,7 +228,7 @@ ActiveRecord::Schema.define(version: 2018_09_05_030558) do
     t.index ["user_id"], name: "index_users_courses_on_user_id"
   end
 
-  create_table "users_events", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4", force: :cascade do |t|
+  create_table "users_events", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci", force: :cascade do |t|
     t.bigint "user_id"
     t.bigint "event_id"
     t.datetime "created_at", null: false

--- a/spec/factories/books.rb
+++ b/spec/factories/books.rb
@@ -15,5 +15,6 @@ FactoryBot.define do
     price { Faker::Number.between(0, 3000) }
     status { Faker::Number.between(0, 3) }
     view_count { 0 }
+    contact_way { Faker::Internet.email }
   end
 end


### PR DESCRIPTION
* 加入新欄位`contact_way`與其假資料，type為`string`
* 修改二手書的新增action，讓新增一筆二手書紀錄時可一併關連至`current_user`
* 加入`current_user`與二手書創建使用者是否相同的檢查及相關測試
* 調整二手書回傳json格式以符合前端要求