### PR TITLE
完成考古題API

### DIFF
--- a/app/models/past_exam.rb
+++ b/app/models/past_exam.rb
@@ -1,25 +1,32 @@
 class PastExam < ApplicationRecord
   belongs_to :course
   belongs_to :uploader, class_name: :User
+  delegate :name, to: :uploader, prefix: true
   mount_base64_uploader :file, PastExamUploader
   def serializable_hash_for_course
-    result = serializable_hash(:only => %I(id description download_count file 
-        created_at updated_at))
-    result[:uploader_id] = result[:uploader][:id]
-    result[:course_id] = result[:course][:id]
-    result[:created_at] = result[:created_at]
-    result[:updated_at] = result[:updated_at]
-    result.except!(:uploader, :course)
+    {}.tap do |result|
+      result[:id] = id
+      result[:description] = description
+      result[:download_count] = download_count
+      result[:file] = { url: file_url }
+      result[:uploader_id] = uploader.id
+      result[:created_at] = created_at
+      result[:updated_at] = updated_at
+    end
   end
-
 
   def serializable_hash(options = nil)
     options = options.try(:dup) || {}
-    super({ **options, except: [:uploader_id, :course_id] }).tap do |result|
-      result[:uploader] = uploader
-      result[:course] = course
-      result[:created_at] = created_at
-      result[:updated_at] = updated_at
+    excepts = %I[uploader_id course_id created_at updated_at]
+    super({ **options, except: excepts }).tap do |result|
+      result[:uploader] = uploader_name
+      result[:course] = {
+        name: course.permanent_course.name,
+        semester: course.semester.serializable_hash_for_past_exam,
+        teacher: course.teachers.try do |course_teachers|
+          course_teachers.map(&:name)
+        end
+      }
     end
   end
 end

--- a/app/models/semester.rb
+++ b/app/models/semester.rb
@@ -2,8 +2,12 @@ class Semester < ApplicationRecord
   has_many :courses
   def serializable_hash_for_course
     {}.tap do |result|
-        result[:year] = year 
-        result[:term] = term
+      result[:year] = year
+      result[:term] = term
     end
+  end
+
+  def serializable_hash_for_past_exam
+    serializable_hash_for_course
   end
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -15,7 +15,7 @@ Rails.application.routes.draw do
           get 'latest_news', to: 'books#latest', as: :latest
         end
       end
-      resources :past_exams
+      resources :past_exams, except: [:show]
       resources :events do
         post 'follow', to: 'events#follow', as: :follow
         delete 'follow', to: 'events#unfollow', as: :unfollow

--- a/spec/factories/past_exams.rb
+++ b/spec/factories/past_exams.rb
@@ -9,6 +9,6 @@ FactoryBot.define do
       )
     end
     uploader { create(:user) }
-    course { create(:course) }
+    course_id { create(:course).id }
   end
 end


### PR DESCRIPTION
### 修改的地方
* 取消`GET /past_exam/:id` 路由
* 刪除`show`action
* 撈取所有考古題紀錄時一併撈取對應的永久課號紀錄，避免N+1 query問題
* 序列化資料為前端規定的格式

### 新增的地方
* 新增使用者ID檢查，確認操作人為資料擁有者
* 新增對於使用者ID檢查的測試