### PR TITLE
心得API

### DIFF
--- a/app/controllers/comments_controller.rb
+++ b/app/controllers/comments_controller.rb
@@ -2,10 +2,12 @@ class CommentsController < ApplicationController
   before_action :set_comment, only: [:show, :update, :destroy]
   before_action :authenticate_user!, except: [:index, :show]
 
+  # GET /comments
   def index
     page = params[:page].try(:to_i) || 1
     per_page = params[:per_page].try(:to_i) || 15
-    filters = Comment.includes(:course, :user).ransack
+    filters = Comment.includes(:course, :user, :course_ratings,
+                               :permanent_course, :teachers).ransack(params[:q])
     @comments = filters.result(distinct: true).page(page).per(per_page)
 
     render json: {
@@ -16,18 +18,27 @@ class CommentsController < ApplicationController
     }
   end
 
+  # GET /comments/:id
   def show
     render json: @comment
   end
 
   # POST /comments
   def create
-    @comment = current_user.comments.build(comment_params)
-
-    if @comment.save
-      render json: @comment, status: :created, location: @comment
+    if !Comment.exists?(user_id: current_user.id, course_id: params[:course_id])
+      @comment = current_user.comments.build(comment_params)
+      if @comment.valid?
+        if @comment.create_course_ratings(params[:rating].scan(/\d/).map(&:to_i))
+          @comment.save
+          render json: @comment, status: :created, location: @comment
+        else
+          render json: { 'error': 'rating out of range' }, status: :unprocessable_entity
+        end
+      else
+        render json: @comment.errors, status: :unprocessable_entity
+      end
     else
-      render json: @comment.errors, status: :unprocessable_entity
+      render json: { 'message': '心得已存在' }, status: :ok
     end
   end
 
@@ -36,19 +47,19 @@ class CommentsController < ApplicationController
     if @comment.user_id != current_user.id
       render json: { 'error': 'user does not match' }, status: :unauthorized
     elsif @comment.update(comment_params)
-      render json: @comment
+      @comment.update_course_ratings(params[:rating].scan(/\d/).map(&:to_i))
+      render json: @comment, status: :ok
     else
       render json: @comment.errors, status: :unprocessable_entity
     end
-    @comment.course_ratings.each do |rating|
-      rating.score = param[:rating][rating.category].to_i
-    end
   end
 
+  # DELETE /comments/:id
   def destroy
     if @comment.user_id != current_user.id
-      render json: @comment.errors, status: :unauthorized
+      render json: { 'error': 'user does not match' }, status: :unauthorized
     else
+      @comment.course_ratings.destroy_all
       @comment.destroy
     end
   end
@@ -56,7 +67,7 @@ class CommentsController < ApplicationController
   private
 
   def set_comment
-    @comment = Comment.includes(:course, :user, :course_ratings).find(params[:id])
+    @comment = Comment.includes(:course, :user, :course_ratings, :permanent_course, :teachers).find(params[:id])
   end
 
   def comment_params

--- a/app/controllers/comments_controller.rb
+++ b/app/controllers/comments_controller.rb
@@ -1,10 +1,11 @@
 class CommentsController < ApplicationController
   before_action :set_comment, only: [:show, :update, :destroy]
   before_action :authenticate_user!, except: [:index, :show]
+
   def index
     page = params[:page].try(:to_i) || 1
     per_page = params[:per_page].try(:to_i) || 15
-    filters = Comment.includes(:course, :user).ransack()
+    filters = Comment.includes(:course, :user).ransack
     @comments = filters.result(distinct: true).page(page).per(per_page)
 
     render json: {
@@ -14,9 +15,11 @@ class CommentsController < ApplicationController
       data: @comments
     }
   end
+
   def show
     render json: @comment
   end
+
   # POST /comments
   def create
     @comment = current_user.comments.build(comment_params)
@@ -27,17 +30,21 @@ class CommentsController < ApplicationController
       render json: @comment.errors, status: :unprocessable_entity
     end
   end
+
   # PATCH /comments/:id
   def update
     if @comment.user_id != current_user.id
-      render json: @comment.errors, status: :unauthorized
+      render json: { 'error': 'user does not match' }, status: :unauthorized
+    elsif @comment.update(comment_params)
+      render json: @comment
+    else
+      render json: @comment.errors, status: :unprocessable_entity
     end
-    @comment.update_attributes(comment_params)
     @comment.course_ratings.each do |rating|
-        rating.score = param[:rating][rating.category].to_i
+      rating.score = param[:rating][rating.category].to_i
     end
-    render json: @comment
   end
+
   def destroy
     if @comment.user_id != current_user.id
       render json: @comment.errors, status: :unauthorized
@@ -45,10 +52,13 @@ class CommentsController < ApplicationController
       @comment.destroy
     end
   end
-private
+
+  private
+
   def set_comment
     @comment = Comment.includes(:course, :user, :course_ratings).find(params[:id])
   end
+
   def comment_params
     params.fetch(:comment, {}).permit(:title, :content, :anonymity, :course_id)
   end

--- a/app/models/comment.rb
+++ b/app/models/comment.rb
@@ -6,9 +6,8 @@ class Comment < ApplicationRecord
   def serializable_hash(options = nil)
     options = options.try(:dup) || {}
     super({ **options, except: [:user_id, :course_id] }).tap do |result|
-      # result[:user] = user.serializable_hash(only: [:id, :name])
-      result[:course] = course.serializable_hash_for_comments # only: [:id, :name])
-
+      result[:course] = course.serializable_hash_for_comments
+      result[:user] = { 'id': user_id, 'name': user.name }
       result[:rating] = '000'
       course_ratings.each do |rating|
         result[:rating][rating.category] = rating.score.to_s

--- a/app/models/comment.rb
+++ b/app/models/comment.rb
@@ -6,12 +6,12 @@ class Comment < ApplicationRecord
   def serializable_hash(options = nil)
     options = options.try(:dup) || {}
     super({ **options, except: [:user_id, :course_id] }).tap do |result|
-      #result[:user] = user.serializable_hash(only: [:id, :name])
-      result[:course] = course.serializable_hash_for_comments()#only: [:id, :name])
+      # result[:user] = user.serializable_hash(only: [:id, :name])
+      result[:course] = course.serializable_hash_for_comments # only: [:id, :name])
 
       result[:rating] = '000'
       course_ratings.each do |rating|
-          result[:rating][rating.category] = rating.score.to_s
+        result[:rating][rating.category] = rating.score.to_s
       end
     end
   end

--- a/app/models/comment.rb
+++ b/app/models/comment.rb
@@ -1,7 +1,15 @@
 class Comment < ApplicationRecord
   belongs_to :course
+  has_one :permanent_course, through: :course
+  has_many :teachers, through: :course
   belongs_to :user
   has_many :course_ratings, through: :user
+
+  # 重載course_ratings方法
+  # 使其只返回該筆心得所對應到的評分紀錄
+  def course_ratings
+    super.where(course_id: course_id, user_id: user_id)
+  end
 
   def serializable_hash(options = nil)
     options = options.try(:dup) || {}
@@ -13,5 +21,27 @@ class Comment < ApplicationRecord
         result[:rating][rating.category] = rating.score.to_s
       end
     end
+  end
+
+  # 建立該筆心得對應的評分紀錄
+  def create_course_ratings(ratings = [0, 0, 0])
+    ratings.each do |rating|
+      return false if rating > 5 || rating.negative?
+    end
+    ratings.each_with_index do |rating, index|
+      user.course_ratings.create course: course, category: index, score: rating
+    end
+    true
+  end
+
+  # 更新該筆心得對應的評分紀錄
+  def update_course_ratings(ratings = [0, 0, 0])
+    previous_rating = course_ratings.order(:category).pluck(:score)
+    return if previous_rating.eql?(ratings) || ratings.nil?
+
+    # Delete old ratings records
+    course_ratings.delete_all
+    # Create updated rating records
+    create_course_ratings(rating)
   end
 end

--- a/app/models/course.rb
+++ b/app/models/course.rb
@@ -77,14 +77,6 @@ class Course < ApplicationRecord
   end
 
   def serializable_hash_for_comments
-    {}.tap do |result|
-      result[:course_id] = id
-      result[:course_name] = permanent_course.name
-      result[:teachers] = [].tap do |i|
-        teachers.each do |teacher|
-          i << teacher.serializable_hash_for_books
-        end
-      end
-    end
+    serializable_hash_for_books
   end
 end

--- a/app/models/course_rating.rb
+++ b/app/models/course_rating.rb
@@ -2,12 +2,11 @@ class CourseRating < ApplicationRecord
   belongs_to :user
   belongs_to :course
 
-  def serializable_hash(option = nil)
-	options = options.try(:dup) || {}
-	super({ **options }).tap do |result|
-	  result[:category] = category
-	  result[:score] = score
-	end
+  def serializable_hash(options = nil)
+    options = options.try(:dup) || {}
+    super({ **options }).tap do |result|
+      result[:category] = category
+      result[:score] = score
+    end
   end
-
 end

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -8,15 +8,21 @@
 
 unless Course.all.size >= 1000
   100.times do
-    course = FactoryBot.create :course
-    course.ratings << Array.new(rand(5)).map { FactoryBot.create :course_rating }
+    FactoryBot.create :course
   end
 end
 
 100.times { FactoryBot.create :book } unless Book.all.size >= 1000
 100.times { FactoryBot.create :past_exam } unless PastExam.all.size >= 1000
 10.times { FactoryBot.create :event } unless Event.all.size >= 50
-10.times { FactoryBot.create :comment } unless Comment.all.size >= 50
+unless Comment.all.length >= 50
+  20.times do
+    comment = FactoryBot.create :comment
+    3.times do |i|
+      comment.user.course_ratings.create FactoryBot.attributes_for :course_rating, category: i, course: comment.course
+    end
+  end
+end
 30.times { FactoryBot.create :bulletin } unless Bulletin.all.size >= 50
 30.times { FactoryBot.create :background } unless Background.all.size >= 150
 30.times { FactoryBot.create :slogan } unless Slogan.all.length >= 150

--- a/spec/factories/comments.rb
+++ b/spec/factories/comments.rb
@@ -1,9 +1,9 @@
 FactoryBot.define do
   factory :comment do
-    title { "MyString" }
-    content { "MyText" }
-    course_id { 1 }
-    user_id { 1 }
-    anonymity { false }
+    title { Faker::Lorem.sentence }
+    content { Faker::Lorem.paragraph }
+    course { create(:course) }
+    user { create(:user) }
+    anonymity { [false, true].sample }
   end
 end

--- a/spec/factories/course_ratings.rb
+++ b/spec/factories/course_ratings.rb
@@ -1,6 +1,6 @@
 FactoryBot.define do
   factory :course_rating do
-    category { Faker::Number.between(0, 3) }
+    category { Faker::Number.between(0, 2) }
     score { Faker::Number.between(0, 5) }
     user { create(:user) }
   end


### PR DESCRIPTION
* 調整序列化(json)格式
* 重載`course_ratings`方法，只返回剛心得對應的評分紀錄而非該使用者所有的評分紀錄
* 調整`comment`的假資料生成方法
* 加入`comment` has_one `permanent_course`關係(經由`course`)
* 加入`comment` has_many `teachers`關係(經由`course`)
* 調整`seeds.rb`內的程式碼以生成假的心得與其對應的評分紀錄