### PR TITLE
Feature/fake data

### DIFF
--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -6,24 +6,52 @@
 #   movies = Movie.create([{ name: 'Star Wars' }, { name: 'Lord of the Rings' }])
 #   Character.create(name: 'Luke', movie: movies.first)
 
-unless Course.all.size >= 1000
-  100.times do
-    FactoryBot.create :course
-  end
-end
+# Create fake user data
+users = FactoryBot.create_list :user, 20
 
-100.times { FactoryBot.create :book } unless Book.all.size >= 1000
-100.times { FactoryBot.create :past_exam } unless PastExam.all.size >= 1000
-10.times { FactoryBot.create :event } unless Event.all.size >= 50
-unless Comment.all.length >= 50
-  20.times do
-    comment = FactoryBot.create :comment
-    [1, 2, 3].sample.times { comment.course.teachers << FactoryBot.create(:teacher) }
-    3.times do |i|
-      comment.user.course_ratings.create FactoryBot.attributes_for :course_rating, category: i, course: comment.course
+# Create department fake data
+departments = FactoryBot.create_list :department, 10 unless Department.all.length >= 30
+
+# Create semester fake data
+semesters = FactoryBot.create_list :semester, 10 unless Semester.all.length >= 30
+
+# Create permanent course fake data
+25.times { FactoryBot.create :permanent_course } unless PermanentCourse.all.length >= 75
+
+# Create course fake data based on the existing permanent course fake data
+PermanentCourse.all.each do |permanent_course|
+  4.times do
+    course = FactoryBot.create :course, permanent_course: permanent_course, department: departments.sample
+    course.semester = semesters.sample
+    course.teachers << FactoryBot.create_list(:teacher, [1, 2, 3].sample)
+    course.save
+
+    # Create associated fake comments and course ratings data
+    (0..3).to_a.sample.times do
+      comment = FactoryBot.create :comment, course: course, user: users.sample
+      3.times do |i|
+        comment.user.course_ratings.create FactoryBot.attributes_for :course_rating, category: i, course: course
+      end
+    end
+
+    # Create associated fake scores and users course data
+    3.times do
+      FactoryBot.create :score, course: course, user: users.sample
+      course.users << users.sample
     end
   end
 end
+
+courses = Course.all
+
+100.times do
+  book = FactoryBot.create :book
+  book.courses << courses.sample([1, 2, 3, 4].sample)
+end
+
+100.times { FactoryBot.create :past_exam, course: courses.sample } unless PastExam.count >= 1000
+10.times { FactoryBot.create :event } unless Event.all.size >= 50
+
 30.times { FactoryBot.create :bulletin } unless Bulletin.all.size >= 50
 30.times { FactoryBot.create :background } unless Background.all.size >= 150
 30.times { FactoryBot.create :slogan } unless Slogan.all.length >= 150

--- a/spec/factories/comments.rb
+++ b/spec/factories/comments.rb
@@ -2,8 +2,11 @@ FactoryBot.define do
   factory :comment do
     title { Faker::Lorem.sentence }
     content { Faker::Lorem.paragraph }
-    course { create(:course) }
-    user { create(:user) }
     anonymity { [false, true].sample }
+  end
+
+  factory :comment_for_rspec_test, parent: :comment do
+    user { create(:user) }
+    course { create(:course) }
   end
 end

--- a/spec/factories/comments.rb
+++ b/spec/factories/comments.rb
@@ -7,6 +7,6 @@ FactoryBot.define do
 
   factory :comment_for_rspec_test, parent: :comment do
     user { create(:user) }
-    course { create(:course) }
+    course { create(:course_for_rspec_test) }
   end
 end

--- a/spec/factories/past_exams.rb
+++ b/spec/factories/past_exams.rb
@@ -9,6 +9,9 @@ FactoryBot.define do
       )
     end
     uploader { create(:user) }
+  end
+
+  factory :past_exam_for_rspec_test, parent: :past_exam do
     course { create(:course) }
   end
 end

--- a/spec/factories/past_exams.rb
+++ b/spec/factories/past_exams.rb
@@ -12,6 +12,6 @@ FactoryBot.define do
   end
 
   factory :past_exam_for_rspec_test, parent: :past_exam do
-    course { create(:course) }
+    course { create(:course_for_rspec_test) }
   end
 end

--- a/spec/factories/permanent_courses.rb
+++ b/spec/factories/permanent_courses.rb
@@ -1,7 +1,7 @@
 FactoryBot.define do
   factory :permanent_course do
     name { Faker::Educator.course_name }
-    code { Faker::Number.between(1_000_000, 9_999_999).to_s }
+    code { ('A'..'Z').to_a.sample(3).join + Faker::Number.between(1000, 9999).to_s }
     description { Faker::Lorem.sentence }
   end
 end

--- a/spec/factories/scores.rb
+++ b/spec/factories/scores.rb
@@ -1,7 +1,10 @@
 FactoryBot.define do
   factory :score do
+    score { [Faker::Number.between(0, 100).to_s, 'W', '\u901a\u904e', '\u4e0d\u901a\u904e'].sample }
+  end
+
+  factory :score_for_rspec_test, parent: :score do
     user { create(:user) }
     course { create(:course) }
-    score { [Faker::Number.between(0, 100).to_s, 'W', '\u901a\u904e', '\u4e0d\u901a\u904e'].sample }
   end
 end

--- a/spec/factories/scores.rb
+++ b/spec/factories/scores.rb
@@ -5,6 +5,6 @@ FactoryBot.define do
 
   factory :score_for_rspec_test, parent: :score do
     user { create(:user) }
-    course { create(:course) }
+    course { create(:course_for_rspec_test) }
   end
 end

--- a/spec/factories/teachers.rb
+++ b/spec/factories/teachers.rb
@@ -2,6 +2,6 @@ FactoryBot.define do
   sequence(:teacher_id) { |n| n }
   factory :teacher do
     id { generate(:teacher_id) }
-    name { Faker::DragonBall.character }
+    name { Faker::Name.name }
   end
 end


### PR DESCRIPTION
* 更改部分model的假資料生成方式
* 假資料生成後，手動加入各自model的relation
* 更改`permanent_course` model中`code`欄位的假資料生成方式，改為生成3個英文字母加上4位數字(與目前永久課號規則相同)
* 加入供rspec測試時使用的factories