### PR TITLE
Fix/comments api

### DIFF
--- a/app/controllers/comments_controller.rb
+++ b/app/controllers/comments_controller.rb
@@ -25,14 +25,16 @@ class CommentsController < ApplicationController
 
   # POST /comments
   def create
-    if !Comment.exists?(user_id: current_user.id, course_id: params[:course_id])
-      @comment = current_user.comments.build(comment_params)
+    course_id = params[:course].try(:[], :id)
+
+    if !Comment.exists?(user_id: current_user.id, course_id: course_id)
+      @comment = current_user.comments.build(comment_params.merge(course_id: params[:course].try(:[], :id)))
       if @comment.valid?
-        if @comment.create_course_ratings(params[:rating].scan(/\d/).map(&:to_i))
+        if @comment.create_course_ratings(params[:rating])
           @comment.save
           render json: @comment, status: :created, location: @comment
         else
-          render json: { 'error': 'rating out of range' }, status: :unprocessable_entity
+          render json: { 'error': 'rating out of range or without ratings data' }, status: :unprocessable_entity
         end
       else
         render json: @comment.errors, status: :unprocessable_entity
@@ -44,10 +46,14 @@ class CommentsController < ApplicationController
 
   # PATCH /comments/:id
   def update
+    course_id = params[:course].try(:[], :id)
+    new_attributes_hash = comment_params
+    new_attributes_hash.merge! course_id.nil? ? { course_id: @comment.course_id } : { course_id: course_id }
+
     if @comment.user_id != current_user.id
       render json: { 'error': 'user does not match' }, status: :unauthorized
-    elsif @comment.update(comment_params)
-      @comment.update_course_ratings(params[:rating].scan(/\d/).map(&:to_i))
+    elsif @comment.update(new_attributes_hash)
+      @comment.update_course_ratings(params[:rating])
       render json: @comment, status: :ok
     else
       render json: @comment.errors, status: :unprocessable_entity

--- a/app/controllers/comments_controller.rb
+++ b/app/controllers/comments_controller.rb
@@ -5,7 +5,7 @@ class CommentsController < ApplicationController
   # GET /comments
   def index
     page = params[:page].try(:to_i) || 1
-    per_page = params[:per_page].try(:to_i) || 15
+    per_page = params[:per_page].try(:to_i) || 25
     filters = Comment.includes(:course, :user, :course_ratings,
                                :permanent_course, :teachers).ransack(params[:q])
     @comments = filters.result(distinct: true).page(page).per(per_page)

--- a/app/models/comment.rb
+++ b/app/models/comment.rb
@@ -44,10 +44,16 @@ class Comment < ApplicationRecord
 
   # 建立該筆心得對應的評分紀錄
   def create_course_ratings(ratings = [0, 0, 0])
-    ratings.each do |rating|
+    # return false if the ratings is nil
+    return false if ratings.nil?
+
+    ratings_array = ratings.scan(/\d/).map(&:to_i)
+
+    # Check if any rating is negative or larger than 5
+    ratings_array.each do |rating|
       return false if rating > 5 || rating.negative?
     end
-    ratings.each_with_index do |rating, index|
+    ratings_array.each_with_index do |rating, index|
       user.course_ratings.create course: course, category: index, score: rating
     end
     true
@@ -55,12 +61,17 @@ class Comment < ApplicationRecord
 
   # 更新該筆心得對應的評分紀錄
   def update_course_ratings(ratings = [0, 0, 0])
+    return if ratings.nil?
+
     previous_rating = course_ratings.order(:category).pluck(:score)
+    ratings_array = ratings.scan(/\d/).map(&:to_i)
+
+    # return if the ratings remain unchanged
     return if previous_rating.eql?(ratings) || ratings.nil?
 
     # Delete old ratings records
     course_ratings.delete_all
     # Create updated rating records
-    create_course_ratings(ratings)
+    create_course_ratings(ratings_array)
   end
 end

--- a/app/models/comment.rb
+++ b/app/models/comment.rb
@@ -57,6 +57,6 @@ class Comment < ApplicationRecord
     # Delete old ratings records
     course_ratings.delete_all
     # Create updated rating records
-    create_course_ratings(rating)
+    create_course_ratings(ratings)
   end
 end

--- a/app/models/comment.rb
+++ b/app/models/comment.rb
@@ -5,7 +5,6 @@ class Comment < ApplicationRecord
   belongs_to :user
   has_many :course_ratings, through: :user
 
-  validates :anonymity, inclusion: { in: [true, false], message: '%{attribute} should be boolean a value' }
   validates :title, :content, presence: { message: '%{attribute} can not be empty' }
   validates :course_id, presence: { message: 'Must specify a course' }
 

--- a/app/models/comment.rb
+++ b/app/models/comment.rb
@@ -13,7 +13,7 @@ class Comment < ApplicationRecord
 
   def serializable_hash(options = nil)
     options = options.try(:dup) || {}
-    super({ **options, except: [:user_id, :course_id] }).tap do |result|
+    super({ **options, except: [:user_id, :course_id, :created_at, :updated_at] }).tap do |result|
       result[:course] = course.serializable_hash_for_comments
       result[:user] = { 'id': user_id, 'name': user.name }
       result[:rating] = '000'

--- a/app/models/comment.rb
+++ b/app/models/comment.rb
@@ -5,6 +5,10 @@ class Comment < ApplicationRecord
   belongs_to :user
   has_many :course_ratings, through: :user
 
+  validates :anonymity, inclusion: { in: [true, false], message: '%{attribute} should be boolean a value' }
+  validates :title, :content, presence: { message: '%{attribute} can not be empty' }
+  validates :course_id, presence: { message: 'Must specify a course' }
+
   # 重載course_ratings方法
   # 使其只返回該筆心得所對應到的評分紀錄
   def course_ratings

--- a/app/models/course.rb
+++ b/app/models/course.rb
@@ -91,8 +91,8 @@ class Course < ApplicationRecord
 
   def serializable_hash_for_comments
     {}.tap do |result|
-      result[:course_id] = id
-      result[:course_name] = permanent_course_name
+      result[:id] = id
+      result[:name] = permanent_course_name
       result[:teachers] = teachers.map(&:name)
     end
   end

--- a/spec/controllers/comments_controller_spec.rb
+++ b/spec/controllers/comments_controller_spec.rb
@@ -1,5 +1,185 @@
 require 'rails_helper'
 
 RSpec.describe CommentsController, type: :controller do
+  let(:valid_attributes) do
+    FactoryBot.attributes_for :comment_for_rspec_test
+  end
 
+  let!(:rating) do
+    3.times.map { rand(4) + 1 }.join.to_s
+  end
+
+  let(:invalid_attributes) do
+    FactoryBot.attributes_for :comment_for_rspec_test, title: nil
+  end
+
+  let(:new_attribute) {{ title: 'I am loser.' }}
+
+  let(:invalid_new_attribute) {{ title: nil }}
+
+  let(:current_user) do
+    FactoryBot.create :user
+  end
+
+  let(:auth_token) do
+    current_user.create_new_auth_token
+  end
+
+  describe 'GET #index' do
+    it 'returns a success response' do
+      Comment.create valid_attributes
+      get :index, params: {}
+      expect(response).to be_successful
+    end
+  end
+
+  describe 'GET #show' do
+    it 'returns a success response' do
+      comment = Comment.create valid_attributes
+      get :show, params: { id: comment.to_param }
+      expect(response).to be_successful
+    end
+  end
+
+  describe 'POST #create' do
+    before(:each) do
+      request.headers.merge! auth_token
+    end
+
+    context 'with valid attributes' do
+      it 'creates a new comment' do
+        expect do
+          post :create, params: { comment: valid_attributes, rating: rating, course: { id: valid_attributes[:course].id } }
+        end.to change(Comment, :count).by(1)
+      end
+
+      it 'renders a json response with the new comment' do
+        post :create, params: { comment: valid_attributes, rating: rating, course: { id: valid_attributes[:course].id } }
+        expect(response).to have_http_status(:created)
+        expect(response.content_type).to eq('application/json')
+        expect(response.location).to eq(comment_url(Comment.last))
+      end
+    end
+
+    context 'with invalid_attributes' do
+      it 'renders a JSON response with errors for new comment' do
+        post :create,
+          params: { comment: invalid_attributes, rating: rating, course: { id: invalid_attributes[:course].id } }
+        expect(response).to have_http_status(:unprocessable_entity)
+        expect(response.content_type).to eq('application/json')
+      end
+
+      it 'does not create a new comment' do
+        expect do
+          post :create,
+            params: { comment: invalid_attributes, rating: rating, course: { id: invalid_attributes[:course].id } }
+        end.to change(Comment, :count).by(0)
+      end
+    end
+
+    context 'with no related course specified' do
+      it 'returns with status code unprocessable_entity' do
+        post :create, params: { comment: invalid_new_attribute, rating: rating }
+        expect(response).to have_http_status(:unprocessable_entity)
+      end
+
+      it 'does not create a new comment' do
+        expect do
+          post :create, params: { comment: invalid_new_attribute, rating: rating }
+        end.to change(Comment, :count).by(0)
+      end
+    end
+
+    context 'the same comment is already existed' do
+      it 'returns with status code ok' do
+        comment = Comment.create valid_attributes
+        comment.update user: current_user
+        post :create, params: { comment: valid_attributes, rating: rating, course: { id: comment.course_id } }
+        expect(response).to have_http_status(:ok)
+      end
+
+      it 'does not create a new comment' do
+        comment = Comment.create valid_attributes
+        comment.update user: current_user
+        expect do
+          post :create, params: { comment: valid_attributes, rating: rating, course: { id: comment.course_id } }
+        end.to change(Comment, :count).by(0)
+      end
+    end
+  end
+
+  describe 'PATCH #update' do
+    before(:each) do
+      request.headers.merge! auth_token
+    end
+
+    context 'with valid attributes' do
+      it 'updates the requested comment' do
+        comment = Comment.create valid_attributes
+        comment.update user: current_user
+        patch :update, params: { id: comment.to_param, comment: new_attribute }
+        comment.reload
+        expect(comment.title).to eq('I am loser.')
+      end
+
+      it 'renders a json response with the requested comment' do
+        comment = Comment.create valid_attributes
+        comment.update user: current_user
+        patch :update, params: { id: comment.to_param, comment: new_attribute }
+        expect(response).to have_http_status(:ok)
+        expect(response.content_type).to eq('application/json')
+      end
+    end
+
+    context 'with invalid attributes' do
+      it 'does not update the requested comment' do
+        comment = Comment.create valid_attributes
+        comment.update user: current_user
+        original_title = comment.title
+        patch :update, params: { id: comment.to_param, comment: invalid_new_attribute }
+        comment.reload
+        expect(comment.title).to eq(original_title)
+      end
+
+      it 'returns with status code unprocessable_entity' do
+        comment = Comment.create valid_attributes
+        comment.update user: current_user
+        patch :update, params: { id: comment.to_param, comment: invalid_new_attribute }
+        expect(response).to have_http_status(:unprocessable_entity)
+      end
+    end
+  end
+
+  describe 'DELETE #destroy' do
+    before(:each) do
+      request.headers.merge! auth_token
+    end
+
+    context 'current user is the creator of the requested comment' do
+      it 'destroys the requested comment' do
+        comment = Comment.create valid_attributes
+        comment.update user: current_user
+        expect do
+          delete :destroy, params: { id: comment.to_param }
+        end.to change(Comment, :count).by(-1)
+      end
+    end
+
+    context 'current user is not the creator of requested comment' do
+      it 'does not destroy the requested comment' do
+        comment = Comment.create valid_attributes
+        comment.update user: FactoryBot.create(:user)
+        expect do
+          delete :destroy, params: { id: comment.to_param }
+        end.to change(Comment, :count).by(0)
+      end
+
+      it 'returns with response code 401'do
+        comment = Comment.create valid_attributes
+        comment.update user: FactoryBot.create(:user)
+        delete :destroy, params: { id: comment.to_param }
+        expect(response).to have_http_status(:unauthorized)
+      end
+    end
+  end
 end


### PR DESCRIPTION
* 修改序列化格式
* 修改一頁預設心得個數為25個
* 新增對於`title`, `content`, `course_id`是否有出現的檢查(model層級的validations)
* 修改`create`, `update`兩actions內容，使其可以綁定課程
* 新增rspec測試