### PR TITLE
Fix/reply api

### DIFF
--- a/app/controllers/reply_controller.rb
+++ b/app/controllers/reply_controller.rb
@@ -15,19 +15,6 @@ class ReplyController < ApplicationController
     end
   end
 
-  def update
-    if current_user.id != @reply.user_id
-      render json: { 'error': 'user does not match' }, status: :unauthorized
-    elsif @reply.comment_id != params[:comment_id].to_i
-      render json: { 'error': 'unmatched comment ID' }, status: :unprocessable_entity
-    elsif @reply.update(reply_params)
-      @reply.update(anonymity: true) if params[:anonymity].is_a? TrueClass
-      render status: :ok
-    else
-      render json: @reply.errors, status: :unprocessable_entity
-    end
-  end
-
   def destroy
     if current_user.id != @reply.user_id
       render json: { 'error': 'user does not match' }, status: :unauthorized

--- a/app/models/reply.rb
+++ b/app/models/reply.rb
@@ -20,7 +20,14 @@ class Reply < ApplicationRecord
     comment.serializable_hash_for_comment_latest_news.tap do |result|
       result[:status] = 1
       result[:time] = created_at
-      result[:reply] = serializable_hash(only: [:anonymity, :id])
+      result[:reply] = {
+        id: id,
+        user: {
+          id: user.id,
+          name: user.name
+        },
+        anonymity: anonymity
+      }
     end
   end
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -35,7 +35,7 @@ Rails.application.routes.draw do
         collection do
           get 'latest_news', to: 'comments#latest'
         end
-        resources :reply, only: [:create, :update, :destroy]
+        resources :reply, only: [:create, :destroy]
       end
       resources :users, only: [:index]
 

--- a/spec/controllers/reply_controller_spec.rb
+++ b/spec/controllers/reply_controller_spec.rb
@@ -53,68 +53,6 @@ RSpec.describe ReplyController, type: :controller do
     end
   end
 
-  describe 'PATCH #update' do
-    before(:each) do
-      request.headers.merge! auth_token
-      request.headers['Content-Type'] = 'application/json'
-    end
-
-    context 'with valid attributes' do
-      it 'updates the requested reply with new content' do
-        reply = Reply.create valid_attributes
-        reply.update user: current_user
-        patch :update, params: { id: reply.to_param, comment_id: reply.comment.id, reply: new_attribute }
-        reply.reload
-        expect(reply.content).to eq('I am loser.')
-      end
-
-      it 'returs with status code ok' do
-        reply = Reply.create valid_attributes
-        reply.update user: current_user
-        patch :update, params: { id: reply.to_param, comment_id: reply.comment.id, reply: new_attribute }
-        expect(response).to have_http_status(:ok)
-      end
-    end
-
-    context 'with invalid attributes' do
-      it 'does not update the requested reply' do
-        reply = Reply.create valid_attributes
-        reply.update user: current_user
-        origin_content = reply.content
-        patch :update, params: { id: reply.to_param, comment_id: reply.comment.id, reply: invalid_new_attribute }
-        reply.reload
-        expect(reply.content).to eq(origin_content)
-      end
-
-      it 'renders a JSON response with status code unprocessable_entity' do
-        reply = Reply.create valid_attributes
-        reply.update user: current_user
-        patch :update, params: { id: reply.to_param, comment_id: reply.comment.id, reply: invalid_new_attribute }
-        expect(response).to have_http_status(:unprocessable_entity)
-        expect(response.content_type).to eq('application/json')
-      end
-    end
-
-    context 'valid_attributes with unmatched comment ID' do
-      it 'does not update the requested reply' do
-        reply = Reply.create valid_attributes
-        reply.update user: current_user
-        origin_content = reply.content
-        patch :update, params: { id: reply.to_param, comment_id: reply.comment_id + 1, reply: new_attribute }
-        reply.reload
-        expect(reply.content).to eq(origin_content)
-      end
-
-      it 'renders a JSON response with status code unprocessable_entity' do
-        reply = Reply.create valid_attributes
-        reply.update user: current_user
-        patch :update, params: { id: reply.to_param, comment_id: reply.comment_id + 1, reply: new_attribute }
-        expect(response).to have_http_status(:unprocessable_entity)
-        expect(response.content_type).to eq('application/json')
-      end
-    end
-  end
-
   describe 'DELETE #destroy' do
     before(:each) do
       request.headers.merge! auth_token


### PR DESCRIPTION
* 移除reply controller中的update action以及相關測試
* 修改心得-最新動態的序列化格式，不論回覆是否為匿名，一律回傳user資訊以供前端判斷是否需顯示刪除按鈕