### PR TITLE
Fix/past exam api

### DIFF
--- a/app/controllers/past_exams_controller.rb
+++ b/app/controllers/past_exams_controller.rb
@@ -26,7 +26,7 @@ class PastExamsController < ApplicationController
     @past_exam = current_user.past_exams.build(past_exam_params.merge(course_id: params[:course].try(:[], :id)))
 
     if @past_exam.save
-      render status: 200
+      render status: :created, location: @past_exam
     else
       render json: @past_exam.errors, status: :unprocessable_entity
     end

--- a/app/models/past_exam.rb
+++ b/app/models/past_exam.rb
@@ -1,5 +1,6 @@
 class PastExam < ApplicationRecord
   belongs_to :course
+  has_one :permanent_course, through: :course
   belongs_to :uploader, class_name: :User
   delegate :name, to: :uploader, prefix: true
   mount_base64_uploader :file, PastExamUploader

--- a/app/models/past_exam.rb
+++ b/app/models/past_exam.rb
@@ -1,6 +1,7 @@
 class PastExam < ApplicationRecord
   belongs_to :course
   has_one :permanent_course, through: :course
+  has_many :teachers, through: :course
   belongs_to :uploader, class_name: :User
   delegate :name, to: :uploader, prefix: true
   mount_base64_uploader :file, PastExamUploader

--- a/spec/controllers/past_exams_controller_spec.rb
+++ b/spec/controllers/past_exams_controller_spec.rb
@@ -56,15 +56,14 @@ RSpec.describe PastExamsController, type: :controller do
     context 'with valid params' do
       it 'creates a new PastExam' do
         expect do
-          post :create, params: { past_exam: valid_attributes }, session: valid_session
+          post :create, params: { past_exam: valid_attributes, course: { id: valid_attributes[:course].id } }, session: valid_session
         end.to change(PastExam, :count).by(1)
       end
 
       it 'renders a JSON response with the new past_exam' do
-        post :create, params: { past_exam: valid_attributes }, session: valid_session
+        post :create, params: { past_exam: valid_attributes, course: { id: valid_attributes[:course].id } }, session: valid_session
         expect(response).to have_http_status(:created)
-        expect(response.content_type).to eq('application/json')
-        expect(response.location).to eq(PastExam.last.file_url)
+        expect(response.location).to eq(past_exam_url(PastExam.last))
       end
     end
   end

--- a/spec/factories/past_exams.rb
+++ b/spec/factories/past_exams.rb
@@ -9,6 +9,7 @@ FactoryBot.define do
       )
     end
     uploader { create(:user) }
+    anonymity { [false, true].sample }
   end
 
   factory :past_exam_for_rspec_test, parent: :past_exam do

--- a/spec/factories/past_exams.rb
+++ b/spec/factories/past_exams.rb
@@ -13,6 +13,6 @@ FactoryBot.define do
   end
 
   factory :past_exam_for_rspec_test, parent: :past_exam do
-    course_id { create(:course_for_rspec_test).id }
+    course { create(:course_for_rspec_test) }
   end
 end


### PR DESCRIPTION
* PastExam加上`has_one` `permanent_course`, `has_many` `teachers`兩relation
* 假資料內加入`anonymity`欄位
* 修正`create` action成功時回傳的狀態碼
* 修正rspec測試錯誤