### PR TITLE
fix /courses/:id/past_exams

### DIFF
--- a/app/controllers/courses_controller.rb
+++ b/app/controllers/courses_controller.rb
@@ -83,16 +83,9 @@ class CoursesController < ApplicationController
   # GET /courses/:id/past_exams
   def past_exams
     course_id = params[:course_id]
-    page = params[:page].try(:to_i) || 1
-    per_page = params[:per_page].try(:to_i) || 25
     past_exams = PastExam.where(course_id: course_id)
-                         .includes(:uploader).page(page).per(per_page)
-    render json: {
-      current_page: page,
-      total_pages: past_exams.total_pages,
-      total_count: past_exams.total_count,
-      data: past_exams.map(&:serializable_hash_for_course)
-    }
+                         .includes(:uploader)
+    render json: past_exams.map(&:serializable_hash_for_course)
   end
 
   # GET /courses/:id/comments

--- a/app/models/past_exam.rb
+++ b/app/models/past_exam.rb
@@ -11,7 +11,11 @@ class PastExam < ApplicationRecord
       result[:description] = description
       result[:download_count] = download_count
       result[:file] = { url: file_url }
-      result[:uploader] = uploader_name
+      result[:uploader] = {
+        id: uploader_id,
+        name: uploader_name
+      }
+      result[:anonymity] = anonymity
     end
   end
 


### PR DESCRIPTION
重寫GET /courses/:id/past_exams的response以符合api document