### PR TITLE
add course to serializable_hash_for_course

### DIFF
--- a/app/models/past_exam.rb
+++ b/app/models/past_exam.rb
@@ -16,6 +16,11 @@ class PastExam < ApplicationRecord
         name: uploader_name
       }
       result[:anonymity] = anonymity
+      result[:course] = {
+        name: course.permanent_course.name,
+        semester: course.semester.serializable_hash_for_past_exam,
+        teacher: course.teachers.map(&:name)
+      }
     end
   end
 


### PR DESCRIPTION
新增course欄位至serializable_hash_for_course
以符合/courses/:id/past_exam的document